### PR TITLE
fix(sidebar): Respect toggled prop

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -38,9 +38,7 @@ const Sidebar = forwardRef(
     });
 
     useEffect(() => {
-      if (toggled) {
-        handleToggleSidebar(!toggled);
-      }
+      handleToggleSidebar(!toggled);
     }, [toggled]);
 
     const sidebarRef = ref ? ref : React.createRef();
@@ -84,8 +82,10 @@ Sidebar.propTypes = {
   textColor: PropTypes.string,
   backgroundColor: PropTypes.string,
   breakpoint: PropTypes.number,
-  toggled: PropTypes.boolean,
+  toggled: PropTypes.bool,
 };
+
+Sidebar.displayName = "Sidebar";
 
 export default Sidebar;
 


### PR DESCRIPTION
The toggled prop's useEffect hook was unable to work properly if "toggled" was false.

Also, the propTypes were incorrectly specified as "PropTypes.boolean" rather than "bool".

Fixes #10 